### PR TITLE
Update ft_atoi.c

### DIFF
--- a/libft/ft_atoi.c
+++ b/libft/ft_atoi.c
@@ -27,9 +27,9 @@ int	ft_atoi(const char *str)
 	}
 	while (ft_isdigit(*str))
 	{
-		if (nagetive && (result * 100) < result)
+		if (nagetive && ((result * 10) + *str - '0')) < result)
 			return (0);
-		else if (!nagetive && (result * 100) < result)
+		else if (!nagetive && ((result * 10) + *str - '0') < result)
 			return (-1);
 		result = result * 10 + (*str++ - '0');
 	}


### PR DESCRIPTION
Protection for overflow replace 100 with the actual math operation ((result * 10) + *str - '0') < result.